### PR TITLE
Remove unicode characters from name string

### DIFF
--- a/lib/ntee.rb
+++ b/lib/ntee.rb
@@ -2,10 +2,16 @@ require 'ntee/version'
 
 module NTEE
   class Category
-    attr_accessor :name, :code, :subcategories, :parent
+    attr_accessor :code, :subcategories, :parent
+    attr_writer :name
 
     def initialize
       self.subcategories ||= {}
+    end
+
+    def name
+      # strip non-ascii characters
+      @name.gsub(/[\u0080-\u00ff]/, "")
     end
 
     def to_s


### PR DESCRIPTION
The ntee categories json dataset has Unicode characters that aren't appropriate. This PR removes any Unicode characters from the name string.

You can see the dataset issues in these two examples, but there are plenty of others:
https://github.com/gively/ntee/blob/master/lib/ntee_categories.json#L1798
https://github.com/gively/ntee/blob/master/lib/ntee_categories.json#L1882
